### PR TITLE
Mistake in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Default: `true`
 This options will pass vinyl objects, that was piped into `watch` to next Stream in pipeline.
 
 #### options.glob
-Type: `String`  
+Type: `String|Array`  
 Default: `undefined`
 
 If you want to detect new files, then you have to use this option. When `gulp-watch` gets files from `gulp.src` it looses the information about pattern of matching - therefore it can not detect new files.


### PR DESCRIPTION
You have mistake in description of `glob` option - it can be an Array resulting same effect as `gulp.src(Array)`.
Am I right?
