### PR TITLE
Add more events from gaze

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,10 @@ module.exports = function (opts, cb) {
 
     duplex.gaze.on('error', duplex.emit.bind(duplex, 'error'));
     duplex.gaze.on('ready', duplex.emit.bind(duplex, 'ready'));
+    duplex.gaze.on('changed', duplex.emit.bind(duplex, 'changed'));
+    duplex.gaze.on('added', duplex.emit.bind(duplex, 'added'));
+    duplex.gaze.on('deleted', duplex.emit.bind(duplex, 'deleted'));
+    duplex.gaze.on('renamed', duplex.emit.bind(duplex, 'renamed'));
 
     duplex.gaze.on('all', function (event, filepath) {
         logEvent(event, filepath, opts);


### PR DESCRIPTION
It is useful to have more events being re-emitted from [gaze](https://github.com/shama/gaze#events), like `added` and `deleted`. For example, I want some pipe actions to be performed only when a file is added, and I'd like to have this event to be triggered in gulp code:

``` javascript
watch({glob: '**/*.js'})
  .on('added', function (file) {
    // file is added
  })
  .pipe(gulp.dest('dist'));
```
