### PR TITLE
Issue #90 "glob should be String or Array, not object" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ function isDirectory(path) {
 module.exports = function (globs, opts, cb) {
     if (!globs) throw new PluginError('gulp-watch', 'glob argument required');
 
+    if (globs.glob) globs = globs.glob;
+
     if (typeof globs === 'string') globs = [ globs ];
 
     if (!Array.isArray(globs)) {


### PR DESCRIPTION
This commit fixes issue #90 by checking if `globs` argument contains the `glob` attribute and uses it instead
