### PR TITLE
unlinked `file.path` should always be absolute, fixes #152; fix tests in Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ var util = require('gulp-util'),
     File = require('vinyl'),
     globParent = require('glob-parent'),
     anymatch = require('anymatch'),
-    isGlob = require('is-glob');
+    isGlob = require('is-glob'),
+    pathIsAbsolute = require('path-is-absolute');
 
 module.exports = function (globs, opts, cb) {
     if (!globs) throw new PluginError('gulp-watch', 'glob argument required');
@@ -57,8 +58,6 @@ module.exports = function (globs, opts, cb) {
     function processEvent(event, filepath) {
         var glob = globs[anymatch(globs, filepath, true)];
 
-        opts.path = filepath;
-
         if (!baseForced) {
             opts.base = isGlob(glob) ? globParent(glob) : path.dirname(glob);
         }
@@ -70,6 +69,7 @@ module.exports = function (globs, opts, cb) {
 
         // Do not stat deleted files
         if (event === 'unlink' || event === 'unlinkDir') {
+            opts.path = pathIsAbsolute(filepath) ? filepath : path.join(opts.cwd || process.cwd(), filepath);
             return write(event, null, new File(opts));
         }
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "glob-parent": "^1.0.0",
     "gulp-util": "~3.0.0",
     "is-glob": "^1.1.0",
+    "path-is-absolute": "^1.0.0",
     "readable-stream": "^1.0.31",
     "vinyl": "^0.4.3",
     "vinyl-file": "~1.1.0"

--- a/test/log.js
+++ b/test/log.js
@@ -9,14 +9,14 @@ var proxyquire = require('proxyquire'),
     }),
     sinon = require('sinon');
 
-var join = require('path').join;
+var path = require('path');
 var touch = require('./touch.js');
 var strip = require('strip-ansi');
 
 require('should');
 
 function fixtures(glob) {
-    return join(__dirname, 'fixtures', glob);
+    return path.join(__dirname, 'fixtures', glob);
 }
 
 describe('log', function () {
@@ -44,7 +44,7 @@ describe('log', function () {
     it('should print relative file name', function (done) {
         w = watch(fixtures('**/*.js'), {verbose: true});
         w.once('data', function () {
-            strip(gutilStub.log.firstCall.args.join(' ')).should.eql('folder/index.js was changed');
+            strip(gutilStub.log.firstCall.args.join(' ')).should.eql(path.normalize('folder/index.js') + ' was changed');
             done();
         }).on('ready', touch(fixtures('folder/index.js')));
     });


### PR DESCRIPTION
Ref: #152 