### PR TITLE
doc(batch): add callback with gulp-batch

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -38,8 +38,8 @@ var batch = require('gulp-batch');
 gulp.task('build', function () { console.log('Working!'); });
 
 gulp.task('watch', function () {
-    watch('**/*.js', batch(function () {
-        gulp.start('build');
+    watch('**/*.js', batch(function (events, done) {
+        gulp.start('build', done);
     }));
 });
 ```


### PR DESCRIPTION
[gulp-batch](https://github.com/floatdrop/gulp-batch#api) requires a callback to tell when it’s done (unless it will never release the batch, and would run the batch once only).