### PR TITLE
Fix consistency of base with gulp.src

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,10 @@ var util = require('gulp-util'),
     Duplex = require('readable-stream').Duplex,
     vinyl = require('vinyl-file'),
     File = require('vinyl'),
-    globParent = require('glob-parent'),
     anymatch = require('anymatch'),
-    isGlob = require('is-glob'),
-    pathIsAbsolute = require('path-is-absolute');
+    pathIsAbsolute = require('path-is-absolute'),
+    glob2base = require('glob2base'),
+    Glob = require('glob').Glob;
 
 module.exports = function (globs, opts, cb) {
     if (!globs) throw new PluginError('gulp-watch', 'glob argument required');
@@ -73,7 +73,7 @@ module.exports = function (globs, opts, cb) {
         var glob = globs[anymatch(globs, filepath, true)];
 
         if (!baseForced) {
-            opts.base = isGlob(glob) ? globParent(glob) : path.dirname(glob);
+            opts.base = glob2base(new Glob(glob));
         }
 
         // React only on opts.events

--- a/index.js
+++ b/index.js
@@ -29,14 +29,19 @@ module.exports = function (globs, opts, cb) {
     cb = cb || function () {};
 
     globs = globs.map(function resolveGlob(glob) {
-        var mod = '';
+        var mod = '',
+            resolveFn = path.resolve;
 
         if (glob[0] === '!') {
             mod = glob[0];
             glob = glob.slice(1);
         }
 
-        return mod + path.resolve(opts.cwd || process.cwd(), glob);
+        if (opts.cwd) {
+            resolveFn = path.normalize;
+        }
+
+        return mod + resolveFn(glob);
     });
 
     opts.events = opts.events || ['add', 'change', 'unlink'];

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
   "dependencies": {
     "anymatch": "^1.3.0",
     "chokidar": "^1.0.3",
-    "glob-parent": "^1.2.0",
+    "glob": "^5.0.13",
+    "glob2base": "0.0.12",
     "gulp-util": "^3.0.6",
-    "is-glob": "^2.0.0",
     "path-is-absolute": "^1.0.0",
     "readable-stream": "^2.0.1",
     "vinyl": "^0.5.0",

--- a/test/test-base.js
+++ b/test/test-base.js
@@ -12,7 +12,11 @@ function fixtures(glob) {
 }
 
 describe('base', function () {
-    var w;
+    var w, watchPath;
+
+    beforeEach(function () {
+        watchPath = './' + path.relative(process.cwd(), fixtures('**/*.js'));
+    });
 
     afterEach(function (done) {
         rimraf.sync(fixtures('newDir'));
@@ -20,10 +24,21 @@ describe('base', function () {
         w.close();
     });
 
-    it('base property should be equal with ./', function (done) {
-        w = watch('./' + path.relative(process.cwd(), fixtures('**/*.js')), function (file) {
-            file.relative.should.eql('folder/index.js');
+    it('should be determined by glob', function (done) {
+        w = watch(watchPath, function (file) {
+                file.relative.should.eql('folder/index.js');
+                file.base.should.eql(fixtures('/'));
+                done();
+            }).on('ready', touch(fixtures('folder/index.js')));
+    });
+
+    it('should be overridden by option', function (done) {
+        var explicitBase = fixtures('folder');
+        w = watch(watchPath, {base: explicitBase}, function (file) {
+            file.relative.should.eql('index.js');
+            file.base.should.eql(explicitBase);
             done();
         }).on('ready', touch(fixtures('folder/index.js')));
     });
+
 });

--- a/test/test-base.js
+++ b/test/test-base.js
@@ -1,8 +1,7 @@
-/* global describe, it, afterEach */
+/* global describe, it, beforeEach, afterEach */
 
 var watch = require('..');
 var path = require('path');
-var fs = require('fs');
 var rimraf = require('rimraf');
 var touch = require('./touch.js');
 require('should');

--- a/test/test-base.js
+++ b/test/test-base.js
@@ -1,4 +1,4 @@
-/* global describe, it, beforeEach, afterEach */
+/* global describe, it, afterEach */
 
 var watch = require('..');
 var path = require('path');
@@ -11,11 +11,7 @@ function fixtures(glob) {
 }
 
 describe('base', function () {
-    var w, watchPath;
-
-    beforeEach(function () {
-        watchPath = './' + path.relative(process.cwd(), fixtures('**/*.js'));
-    });
+    var w;
 
     afterEach(function (done) {
         rimraf.sync(fixtures('newDir'));
@@ -24,7 +20,7 @@ describe('base', function () {
     });
 
     it('should be determined by glob', function (done) {
-        w = watch(watchPath, function (file) {
+        w = watch(fixtures('**/*.js'), function (file) {
                 file.relative.should.eql('folder/index.js');
                 file.base.should.eql(fixtures('/'));
                 done();
@@ -33,7 +29,7 @@ describe('base', function () {
 
     it('should be overridden by option', function (done) {
         var explicitBase = fixtures('folder');
-        w = watch(watchPath, {base: explicitBase}, function (file) {
+        w = watch(fixtures('**/*.js'), {base: explicitBase}, function (file) {
             file.relative.should.eql('index.js');
             file.base.should.eql(explicitBase);
             done();

--- a/test/test-cwd.js
+++ b/test/test-cwd.js
@@ -2,7 +2,6 @@
 
 var watch = require('..');
 var path = require('path');
-var fs = require('fs');
 var rimraf = require('rimraf');
 var touch = require('./touch.js');
 require('should');


### PR DESCRIPTION
In order to match gulp.src (vinyl-fs.src) behavior change base to use glob2base and glob instead of globParent and remove path.dirname behavior.

This is to fix #182 