### PR TITLE
Fix "add" API method

### DIFF
--- a/test/test-api.js
+++ b/test/test-api.js
@@ -1,0 +1,46 @@
+/* global describe, it, afterEach */
+
+var watch = require('..');
+var join = require('path').join;
+var touch = require('./touch.js');
+var fs = require('fs');
+var rimraf = require('rimraf');
+require('should');
+
+function fixtures(glob) {
+    return join(__dirname, 'fixtures', glob);
+}
+
+describe('api', function () {
+    var w;
+
+    describe('add', function() {
+        afterEach(function (done) {
+            w.on('end', function () {
+                rimraf.sync(fixtures('new.js'));
+                done();
+            });
+            w.close();
+        });
+
+        it('should emit added file', function (done) {
+            w = watch(fixtures('*/*.js'));
+            w.add(fixtures('*.js'));
+            w.on('data', function (file) {
+                file.relative.should.eql('new.js');
+                file.event.should.eql('add');
+                done();
+            }).on('ready', touch(fixtures('new.js')));
+        });
+
+        it('should emit change event on file change', function (done) {
+            w = watch(fixtures('*/*.js'));
+            w.add(fixtures('*.js'));
+            w.on('ready', touch(fixtures('index.js')));
+            w.on('data', function (file) {
+                file.relative.should.eql('index.js');
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
gulp-watch exposes the watchers "add" method, but adding patterns to watch via this method does not work.

That's because on add/change event, the file path of the added/changed file is only looked up in the pattern list that was directly passed to gulp-watch. Since patterns that are added later to the watcher are not in that list, an error is thrown in https://github.com/floatdrop/gulp-watch/blob/master/index.js#L81:

```js
Uncaught TypeError: glob pattern string required
```

This change provides a custom "add" method implementation which adds the passed patterns to the internal pattern list.