### PR TITLE
Test on Windows, fixes #207

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ language: node_js
 node_js:
   - '0.10'
   - '0.12'
+  - '4'
   - 'stable'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [gulp](https://github.com/gulpjs/gulp)-watch [![Build Status][travis-image]][travis-url] [![Dependency Status][depstat-image]][depstat-url]
+# [gulp](https://github.com/gulpjs/gulp)-watch [![Build Status: Linux][travis-image]][travis-url] [![Build Status: Windows][appveyor-image]][appveyor-url] [![Dependency Status][depstat-image]][depstat-url]
 
 File watcher that uses super-fast [chokidar](https://github.com/paulmillr/chokidar) and emits vinyl objects.
 
@@ -122,6 +122,9 @@ MIT (c) 2014 Vsevolod Strukchinsky (floatdrop@gmail.com)
 
 [travis-url]: https://travis-ci.org/floatdrop/gulp-watch
 [travis-image]: http://img.shields.io/travis/floatdrop/gulp-watch.svg?style=flat
+
+[appveyor-url]: https://ci.appveyor.com/project/UltCombo/gulp-watch/branch/master
+[appveyor-image]: https://ci.appveyor.com/api/projects/status/xscfpq7hkf8gduj8/branch/master?svg=true
 
 [depstat-url]: https://david-dm.org/floatdrop/gulp-watch
 [depstat-image]: http://img.shields.io/david/floatdrop/gulp-watch.svg?style=flat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+environment:
+  matrix:
+    - nodejs_version: '5'
+    - nodejs_version: '4'
+    - nodejs_version: '0.12'
+    - nodejs_version: '0.10'
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - set CI=true
+  - npm -g install npm@latest
+  - set PATH=%APPDATA%\npm;%PATH%
+  - npm install
+matrix:
+  fast_finish: true
+build: off
+version: '{build}'
+shallow_clone: true
+clone_depth: 1
+test_script:
+  - node --version
+  - npm --version
+  - npm test

--- a/test/test-base.js
+++ b/test/test-base.js
@@ -21,7 +21,7 @@ describe('base', function () {
 
 	it('should be determined by glob', function (done) {
 		w = watch(fixtures('**/*.js'), function (file) {
-			file.relative.should.eql('folder/index.js');
+			file.relative.should.eql(path.normalize('folder/index.js'));
 			file.base.should.eql(fixtures('/'));
 			done();
 		}).on('ready', touch(fixtures('folder/index.js')));

--- a/test/test-cwd.js
+++ b/test/test-cwd.js
@@ -21,7 +21,7 @@ describe('cwd', function () {
 
 	it('should respect opts.cwd', function (done) {
 		w = watch('index.js', {cwd: fixtures('')}, function (file) {
-			file.relative.should.eql('test/fixtures/index.js');
+			file.relative.should.eql(path.normalize('test/fixtures/index.js'));
 			done();
 		}).on('ready', touch(fixtures('index.js')));
 	});


### PR DESCRIPTION
- Add AppVeyor integration
- Normalize expected paths as to not fail assertions due to Windows-style directory separators

AppVeyor config adapted from [Ava's](https://github.com/sindresorhus/ava/blob/4399e7b53ace394ec8627cad58302d4bf55a7c45/appveyor.yml).