### PR TITLE
Fix crash when editing file inside watched directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,10 @@ module.exports = function (globs, opts, cb) {
 	function processEvent(event, filepath) {
 		var glob = globs[anymatch(globs, filepath, true)];
 
+		if (!glob) {
+			return;
+		}
+
 		if (!baseForced) {
 			opts.base = glob2base(new Glob(glob));
 		}

--- a/test/test-dir.js
+++ b/test/test-dir.js
@@ -1,0 +1,37 @@
+/* global describe, it, afterEach */
+
+var watch = require('..');
+var path = require('path');
+var fs = require('fs');
+var rimraf = require('rimraf');
+var touch = require('./touch.js');
+require('should');
+
+function fixtures(glob) {
+	return path.join(__dirname, 'fixtures', glob);
+}
+
+describe('dir', function () {
+	var w;
+
+	afterEach(function (done) {
+		rimraf.sync(fixtures('newDir'));
+		w.on('end', done);
+		w.close();
+	});
+
+	it('should not watch files inside directory', function (done) {
+		fs.mkdirSync(fixtures('newDir'));
+		touch(fixtures('newDir/index.js'))();
+		w = watch(fixtures('newDir'), function () {
+			done('Watched unexpected file.');
+		}).on('ready', function () {
+			touch(fixtures('newDir/index.js'))('new content');
+			setTimeout(done, 200);
+		});
+	});
+
+	it('should watch directory creation');
+
+	it('should watch directory removal');
+});


### PR DESCRIPTION
Also better align behavior with `gulp.watch`.

Reference: https://github.com/floatdrop/gulp-watch/issues/206#issuecomment-155264225