### PR TITLE
Passing a directory path implicitly watches directory contents, undoes accidental breaking change and fixes #229

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,20 +38,22 @@ module.exports = function (globs, opts, cb) {
 	opts = opts || {};
 	cb = cb || function () {};
 
+	function resolveFilepath(filepath) {
+		if (pathIsAbsolute(filepath)) {
+			return filepath;
+		}
+		return path.resolve(opts.cwd || process.cwd(), filepath);
+	}
+
 	function resolveGlob(glob) {
 		var mod = '';
-		var resolveFn = path.resolve;
 
 		if (glob[0] === '!') {
 			mod = glob[0];
 			glob = glob.slice(1);
 		}
 
-		if (opts.cwd) {
-			resolveFn = path.normalize;
-		}
-
-		return mod + resolveFn(glob);
+		return mod + resolveFilepath(glob);
 	}
 	globs = globs.map(resolveGlob);
 
@@ -98,9 +100,7 @@ module.exports = function (globs, opts, cb) {
 	};
 
 	function processEvent(event, filepath) {
-		if (!pathIsAbsolute(filepath)) {
-			filepath = path.resolve(opts.cwd || process.cwd(), filepath);
-		}
+		filepath = resolveFilepath(filepath);
 
 		var glob;
 		var currentFilepath = filepath;

--- a/index.js
+++ b/index.js
@@ -98,6 +98,10 @@ module.exports = function (globs, opts, cb) {
 	};
 
 	function processEvent(event, filepath) {
+		if (!pathIsAbsolute(filepath)) {
+			filepath = path.resolve(opts.cwd || process.cwd(), filepath);
+		}
+
 		var glob;
 		var currentFilepath = filepath;
 		while (!(glob = globs[anymatch(globs, currentFilepath, true)]) && currentFilepath !== (currentFilepath = path.resolve(currentFilepath, '..'))) {} // eslint-disable-line no-empty-blocks/no-empty-blocks
@@ -119,7 +123,7 @@ module.exports = function (globs, opts, cb) {
 
 		// Do not stat deleted files
 		if (event === 'unlink' || event === 'unlinkDir') {
-			opts.path = pathIsAbsolute(filepath) ? filepath : path.join(opts.cwd || process.cwd(), filepath);
+			opts.path = filepath;
 
 			write(event, null, new File(opts));
 			return;

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   },
   "dependencies": {
     "anymatch": "^1.3.0",
-    "chokidar": "^1.0.3",
-    "glob": "^5.0.13",
+    "chokidar": "^1.5.2",
+    "glob": "^7.0.3",
     "glob2base": "0.0.12",
     "gulp-util": "^3.0.6",
     "path-is-absolute": "^1.0.0",

--- a/test/test-cwd.js
+++ b/test/test-cwd.js
@@ -21,7 +21,7 @@ describe('cwd', function () {
 
 	it('should respect opts.cwd', function (done) {
 		w = watch('index.js', {cwd: fixtures('')}, function (file) {
-			file.relative.should.eql(path.normalize('test/fixtures/index.js'));
+			file.relative.should.eql(path.normalize('index.js'));
 			done();
 		}).on('ready', touch(fixtures('index.js')));
 	});

--- a/test/test-cwd.js
+++ b/test/test-cwd.js
@@ -21,15 +21,24 @@ describe('cwd', function () {
 
 	it('should respect opts.cwd', function (done) {
 		w = watch('index.js', {cwd: fixtures('')}, function (file) {
-			file.relative.should.eql(path.normalize('index.js'));
+			file.relative.should.eql('index.js');
 			done();
 		}).on('ready', touch(fixtures('index.js')));
 	});
 
-	it('should emit file outside opts.cwd', function (done) {
+	it('should emit file outside opts.cwd using relative glob', function (done) {
+		w = watch('../index.js', {cwd: fixtures('folder')}, function (file) {
+			file.relative.should.eql('index.js');
+			file.contents.toString().should.equal('fixtures index');
+			done();
+		}).on('ready', touch(fixtures('index.js'), 'fixtures index'));
+	});
+
+	it('should emit file outside opts.cwd using absolute glob', function (done) {
 		w = watch(fixtures('index.js'), {cwd: fixtures('folder')}, function (file) {
 			file.relative.should.eql('index.js');
+			file.contents.toString().should.equal('fixtures index');
 			done();
-		}).on('ready', touch(fixtures('index.js')));
+		}).on('ready', touch(fixtures('index.js'), 'fixtures index'));
 	});
 });

--- a/test/test-cwd.js
+++ b/test/test-cwd.js
@@ -25,4 +25,11 @@ describe('cwd', function () {
 			done();
 		}).on('ready', touch(fixtures('index.js')));
 	});
+
+	it('should emit file outside opts.cwd', function (done) {
+		w = watch(fixtures('index.js'), {cwd: fixtures('folder')}, function (file) {
+			file.relative.should.eql('index.js');
+			done();
+		}).on('ready', touch(fixtures('index.js')));
+	});
 });

--- a/test/test-dir.js
+++ b/test/test-dir.js
@@ -20,14 +20,14 @@ describe('dir', function () {
 		w.close();
 	});
 
-	it('should not watch files inside directory', function (done) {
+	it('should watch files inside directory', function (done) {
 		fs.mkdirSync(fixtures('newDir'));
 		touch(fixtures('newDir/index.js'))();
-		w = watch(fixtures('newDir'), function () {
-			done('Watched unexpected file.');
+		w = watch(fixtures('newDir'), function (file) {
+			file.relative.should.eql(path.normalize('newDir/index.js'));
+			done();
 		}).on('ready', function () {
 			touch(fixtures('newDir/index.js'))('new content');
-			setTimeout(done, 200);
 		});
 	});
 


### PR DESCRIPTION
Also refactor event filtering and add logging for unexpected watched files.