### PR TITLE
Rewrite vinyl.read as Promise in order to update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,9 @@ function watch(globs, opts, cb) {
 
 		// Workaround for early read
 		setTimeout(function () {
-			vinyl.read(filepath, fileOpts, write.bind(null, event));
+			vinyl.read(filepath, fileOpts).then(function (file) {
+				write(event, null, file);
+			});
 		}, opts.readDelay);
 	}
 

--- a/package.json
+++ b/package.json
@@ -41,13 +41,13 @@
   "dependencies": {
     "anymatch": "^1.3.0",
     "chokidar": "^1.5.2",
-    "glob-parent": "^2.0.0",
+    "glob-parent": "^3.0.0",
     "gulp-util": "^3.0.6",
     "object-assign": "^4.1.0",
     "path-is-absolute": "^1.0.0",
     "readable-stream": "^2.0.1",
-    "vinyl": "^0.5.0",
-    "vinyl-file": "^1.2.1"
+    "vinyl": "^1.2.0",
+    "vinyl-file": "^2.0.0"
   },
   "engine": "node >= 0.10"
 }


### PR DESCRIPTION
Hello! I hope this update will be useful.
I've only one question...

```javascript
     // Workaround for early read
     setTimeout(function () {
       vinyl.read(filepath, fileOpts).then(function (file) {
         write(event, null, file);
       });
     }, opts.readDelay);
```

Without ```setTimeout``` all tests pass green. Should leave ```setTimeout```? remove it?
