### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 'use strict';
-var util = require('gulp-util');
 var assign = require('object-assign');
 var path = require('path');
-var PluginError = require('gulp-util').PluginError;
+var PluginError = require('plugin-error');
+var fancyLog = require('fancy-log');
+var colors = require('ansi-colors');
 var chokidar = require('chokidar');
 var Duplex = require('readable-stream').Duplex;
 var vinyl = require('vinyl-file');
@@ -102,9 +103,9 @@ function watch(globs, opts, cb) {
 		while (!(glob = globs[anymatch(globs, currentFilepath, true)]) && currentFilepath !== (currentFilepath = path.dirname(currentFilepath))) {} // eslint-disable-line no-empty-blocks/no-empty-blocks
 
 		if (!glob) {
-			util.log(
-				util.colors.cyan('[gulp-watch]'),
-				util.colors.yellow('Watched unexpected path. This is likely a bug. Please open this link to report the issue:\n') +
+			fancyLog.info(
+				colors.cyan('[gulp-watch]'),
+				colors.yellow('Watched unexpected path. This is likely a bug. Please open this link to report the issue:\n') +
 				'https://github.com/floatdrop/gulp-watch/issues/new?title=' +
 				encodeURIComponent('Watched unexpected filepath') + '&body=' +
 				encodeURIComponent('Node.js version: `' + process.version + ' ' + process.platform + ' ' + process.arch + '`\ngulp-watch version: `' + require('./package.json').version + '`\nGlobs: `' + JSON.stringify(originalGlobs) + '`\nFilepath: `' + filepath + '`\nEvent: `' + event + '`\nProcess CWD: `' + process.cwd() + '`\nOptions:\n```js\n' + JSON.stringify(opts, null, 2) + '\n```')
@@ -150,13 +151,13 @@ function watch(globs, opts, cb) {
 	function log(event, file) {
 		event = event[event.length - 1] === 'e' ? event + 'd' : event + 'ed';
 
-		var msg = [util.colors.magenta(file.relative), 'was', event];
+		var msg = [colors.magenta(file.relative), 'was', event];
 
 		if (opts.name) {
-			msg.unshift(util.colors.cyan(opts.name) + ' saw');
+			msg.unshift(colors.cyan(opts.name) + ' saw');
 		}
 
-		util.log.apply(util, msg);
+		fancyLog.info.apply(null, msg);
 	}
 
 	return outputStream;

--- a/package.json
+++ b/package.json
@@ -39,12 +39,14 @@
     "xo": "^0.10.1"
   },
   "dependencies": {
+    "ansi-colors": "1.1.0",
     "anymatch": "^1.3.0",
     "chokidar": "^2.0.0",
+    "fancy-log": "1.3.2",
     "glob-parent": "^3.0.1",
-    "gulp-util": "^3.0.7",
     "object-assign": "^4.1.0",
     "path-is-absolute": "^1.0.1",
+    "plugin-error": "1.0.1",
     "readable-stream": "^2.2.2",
     "slash": "^1.0.0",
     "vinyl": "^2.1.0",

--- a/test/test-log.js
+++ b/test/test-log.js
@@ -1,11 +1,11 @@
 /* global beforeEach, afterEach, describe, it */
 
 var proxyquire = require('proxyquire');
-var gutilStub = {
-	log: function () { }
+var fancyLogStub = {
+	info: function () { }
 };
 var watch = proxyquire('..', {
-	'gulp-util': gutilStub
+	'fancy-log': fancyLogStub
 });
 var sinon = require('sinon');
 
@@ -23,11 +23,11 @@ describe('log', function () {
 	var w;
 
 	beforeEach(function () {
-		sinon.spy(gutilStub, 'log');
+		sinon.spy(fancyLogStub, 'info');
 	});
 
 	afterEach(function (done) {
-		gutilStub.log.restore();
+		fancyLogStub.info.restore();
 		w.on('end', done);
 		w.close();
 	});
@@ -35,8 +35,8 @@ describe('log', function () {
 	it('should print file name', function (done) {
 		w = watch(fixtures('*.js'), {verbose: true});
 		w.once('data', function () {
-			gutilStub.log.calledOnce.should.be.eql(true);
-			strip(gutilStub.log.firstCall.args.join(' ')).should.eql('index.js was changed');
+			fancyLogStub.info.calledOnce.should.be.eql(true);
+			strip(fancyLogStub.info.firstCall.args.join(' ')).should.eql('index.js was changed');
 			done();
 		}).on('ready', touch(fixtures('index.js')));
 	});
@@ -44,7 +44,7 @@ describe('log', function () {
 	it('should print relative file name', function (done) {
 		w = watch(fixtures('**/*.js'), {verbose: true});
 		w.once('data', function () {
-			strip(gutilStub.log.firstCall.args.join(' ')).should.eql(path.normalize('folder/index.js') + ' was changed');
+			strip(fancyLogStub.info.firstCall.args.join(' ')).should.eql(path.normalize('folder/index.js') + ' was changed');
 			done();
 		}).on('ready', touch(fixtures('folder/index.js')));
 	});
@@ -52,8 +52,8 @@ describe('log', function () {
 	it('should print custom watcher name', function (done) {
 		w = watch(fixtures('*.js'), {name: 'Watch', verbose: true});
 		w.once('data', function () {
-			gutilStub.log.calledOnce.should.be.eql(true);
-			strip(gutilStub.log.firstCall.args.join(' ')).should.eql('Watch saw index.js was changed');
+			fancyLogStub.info.calledOnce.should.be.eql(true);
+			strip(fancyLogStub.info.firstCall.args.join(' ')).should.eql('Watch saw index.js was changed');
 			done();
 		}).on('ready', touch(fixtures('index.js')));
 	});


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp, it is important to replace `gulp-util`.

Your package is popular but still relying on `gulp-util`, it would be good to publish a fixed version to npm as soon as possible.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143