### PR TITLE
Fix for paths with non-ASCII characters on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var File = require('vinyl');
 var anymatch = require('anymatch');
 var pathIsAbsolute = require('path-is-absolute');
 var globParent = require('glob-parent');
-var slash = require('slash');
+var normalize = require('normalize-path');
 
 function normalizeGlobs(globs) {
 	if (!globs) {
@@ -56,7 +56,7 @@ function watch(globs, opts, cb) {
 			glob = glob.slice(1);
 		}
 
-		return mod + slash(resolveFilepath(glob));
+		return mod + normalize(resolveFilepath(glob));
 	}
 	globs = globs.map(resolveGlob);
 

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     "chokidar": "^2.0.0",
     "fancy-log": "1.3.2",
     "glob-parent": "^3.0.1",
+    "normalize-path": "^3.0.0",
     "object-assign": "^4.1.0",
     "path-is-absolute": "^1.0.1",
     "plugin-error": "1.0.1",
     "readable-stream": "^2.2.2",
-    "slash": "^1.0.0",
     "vinyl": "^2.1.0",
     "vinyl-file": "^2.0.0"
   },


### PR DESCRIPTION
Replace `slash` with `normalize-path`. This fixes the issue #306 related to non-working globs on some Windows machines.

The `slash` function doesn't replace backslashes in paths containing non-ascii characters, whereas chokidar only supports globs with forward slashes. So if any path component (e.g. the name of the user's home directory) contains characters from a different alphabet, chokidar doesn't report events. Using `normalize-path` instead of `slash` solves the problem as it supports non-ascii symbols.

- [slash](https://www.npmjs.com/package/slash)
- [normalize-path](https://www.npmjs.com/package/normalize-path)